### PR TITLE
Fix emails parsing where from/to contains full names

### DIFF
--- a/lib/receivex/adapters/mailgun.ex
+++ b/lib/receivex/adapters/mailgun.ex
@@ -48,15 +48,14 @@ defmodule Receivex.Adapter.Mailgun do
     parse_address(from)
   end
 
+  @regex ~r/(?<name>.*)<(?<email>.*)>/
   defp parse_address(address) do
-    case address |> String.split(" ") do
-      [name, email] ->
-        email = email |> String.trim_leading("<") |> String.trim_trailing(">")
-        {name, email}
+    result = Regex.named_captures(@regex, address)
 
-      [email] ->
-        {nil, email}
-    end
+    {
+      String.trim(result["name"]),
+      String.trim(result["email"])
+    }
   end
 
   defp recipients(%{"To" => recipients}) do

--- a/test/adapters/mailgun_test.exs
+++ b/test/adapters/mailgun_test.exs
@@ -7,7 +7,7 @@ defmodule Receivex.Adapter.MailgunTest do
   @mailgun_params %{
     "Content-Type" => "multipart/mixed; boundary=\"------------020601070403020003080006\"",
     "Date" => "Fri, 26 Apr 2013 11:50:29 -0700",
-    "From" => "Bob <bob@mg.example.com>",
+    "From" => "From Bob <bob@mg.example.com>",
     "In-Reply-To" => "<517AC78B.5060404@mg.example.com>",
     "Message-Id" => "<517ACC75.5010709@mg.example.com>",
     "Mime-Version" => "1.0",
@@ -16,7 +16,7 @@ defmodule Receivex.Adapter.MailgunTest do
     "References" => "<517AC78B.5060404@mg.example.com>",
     "Sender" => "bob@mg.example.com",
     "Subject" => "Re: Sample POST request",
-    "To" => "Alice <alice@mg.example.com>",
+    "To" => "To Alice <alice@mg.example.com>",
     "User-Agent" => "Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20130308 Thunderbird/17.0.4",
     "X-Mailgun-Variables" => "{\"my_var_1\": \"Mailgun Variable #1\", \"my-var-2\": \"awesome\"}",
     "attachment-1" => %Plug.Upload{
@@ -80,12 +80,12 @@ defmodule Receivex.Adapter.MailgunTest do
     text = @mailgun_params["body-plain"]
 
     assert %Receivex.Email{
-             from: {"Bob", "bob@mg.example.com"},
+             from: {"From Bob", "bob@mg.example.com"},
              html: html,
              sender: "bob@mg.example.com",
              subject: "Re: Sample POST request",
              text: text,
-             to: [{"Alice", "alice@mg.example.com"}]
+             to: [{"To Alice", "alice@mg.example.com"}]
            } == Adapter.Mailgun.normalize_params(@mailgun_params)
   end
 end


### PR DESCRIPTION
Hi!. 
If we send mails from/to recipients that contains more that one word in their names, ie "Bob Marley", `receivex` fails with error 
```
(CaseClauseError) no case clause matching: ["Bob", "Marley", "<forwarding-noreply@google.com>"]
```

I've changed name extracting from basic "\s" splitting into basic regular expression matching.