### PR TITLE
Small refactor to make generic. Allow for custom response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [![Build Status](https://travis-ci.com/maartenvanvliet/receivex.svg?branch=master)](https://travis-ci.com/maartenvanvliet/receivex) [![Hex pm](http://img.shields.io/hexpm/v/receivex.svg?style=flat)](https://hex.pm/packages/receivex) [![Hex Docs](https://img.shields.io/badge/hex-docs-9768d1.svg)](https://hexdocs.pm/receivex) [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Package to deal with inbound email webhooks for several providers. Right now 
-Mailgun and Mandrill are supported.
+Package that makes it easy to deal with inbound webhooks.
 
+## Adapters
+
+Right now [Mailgun](./lib/receivex/adapters/mailgun.ex) and [Mandrill](./lib/receivex/adapters/mandrill.ex) webhooks are supported out of the box.
+
+You can implement your own adapter by following the existing adapters as an example.
 
 ## Installation
 

--- a/lib/receivex/adapter.ex
+++ b/lib/receivex/adapter.ex
@@ -1,9 +1,12 @@
 defmodule Receivex.Adapter do
   @moduledoc """
-  Behaviour for handling webhooks for different providers
+  Behaviour for handling webhooks
   """
   @callback handle_webhook(conn :: Plug.Conn.t(), handler :: Atom.t(), opts :: []) ::
-              {:ok, conn :: Plug.Conn.t()} | {:error, conn :: Plug.Conn.t(), String.t()}
+              {:ok, conn :: Plug.Conn.t()}
+              | {:ok, conn :: Plug.Conn.t(), map()}
+              | {:error, conn :: Plug.Conn.t(), String.t()}
+              | {:error, conn :: Plug.Conn.t(), String.t(), map()}
 
-  @callback normalize_params(email :: any) :: Receivex.Email.t() | nil
+  @callback normalize_params(payload :: any()) :: struct() | nil
 end

--- a/lib/receivex/handler.ex
+++ b/lib/receivex/handler.ex
@@ -1,6 +1,18 @@
 defmodule Receivex.Handler do
   @moduledoc """
-  Behaviour for handling incoming email
+  Behaviour for handling incoming webhook
   """
-  @callback process(email :: Receivex.Email.t()) :: :ok | {:error, String.t()}
+  @callback process(payload :: struct()) :: :ok | {:error, any()}
 end
+
+forward("_incoming",
+  to: Receivex,
+  init_opts: [
+    adapter: Receivex.Adapter.Mandrill,
+    adapter_opts: [
+      secret: "i8PTcm8glMgsfaWf75bS1FQ",
+      url: "http://example.com"
+    ],
+    handler: Example.Processor
+  ]
+)

--- a/test/receivex_test.exs
+++ b/test/receivex_test.exs
@@ -11,6 +11,22 @@ defmodule ReceivexTest do
         %{"invalid" => "true"} ->
           {:error, conn}
 
+        %{"error_response" => "true"} ->
+          error_response = %{
+            code: :bad_request,
+            body: %{message: "Bad Request"}
+          }
+
+          {:error, conn, error_response}
+
+        %{"ok_response" => "true"} ->
+          response = %{
+            code: :ok,
+            body: %{hello: "World"}
+          }
+
+          {:ok, conn, response}
+
         _ ->
           email = normalize_params(conn.body_params)
 
@@ -58,17 +74,48 @@ defmodule ReceivexTest do
                     }}
   end
 
-  test "returns error for invalid mail requests" do
-    conn =
-      conn(:post, "/_incoming", "invalid=true&subject=Hello+World&from=test%40example.com")
-      |> put_req_header("content-type", "application/x-www-form-urlencoded")
+  describe "webhook responses" do
+    test "returns user-provided response" do
+      conn =
+        conn(:post, "/_incoming", "ok_response=true")
+        |> put_req_header("content-type", "application/x-www-form-urlencoded")
 
-    conn = Plug.Parsers.call(conn, Plug.Parsers.init(parsers: [:urlencoded, :multipart]))
-    conn = Receivex.call(conn, @opts)
+      conn = Plug.Parsers.call(conn, Plug.Parsers.init(parsers: [:urlencoded, :multipart]))
+      conn = Receivex.call(conn, @opts)
 
-    assert 403 == conn.status
-    assert conn.halted
+      assert conn.status == 200
+      assert conn.resp_body == "{\"body\":{\"hello\":\"World\"},\"code\":\"ok\"}"
+      assert conn.halted
+    end
 
-    refute_receive {:email, _}
+    test "returns standard error response" do
+      conn =
+        conn(:post, "/_incoming", "invalid=true&subject=Hello+World&from=test%40example.com")
+        |> put_req_header("content-type", "application/x-www-form-urlencoded")
+
+      conn = Plug.Parsers.call(conn, Plug.Parsers.init(parsers: [:urlencoded, :multipart]))
+      conn = Receivex.call(conn, @opts)
+
+      assert conn.status == 403
+      assert conn.resp_body == "bad signature"
+      assert conn.halted
+
+      refute_receive {:email, _}
+    end
+
+    test "returns user-provided error response" do
+      conn =
+        conn(:post, "/_incoming", "error_response=true")
+        |> put_req_header("content-type", "application/x-www-form-urlencoded")
+
+      conn = Plug.Parsers.call(conn, Plug.Parsers.init(parsers: [:urlencoded, :multipart]))
+      conn = Receivex.call(conn, @opts)
+
+      assert conn.status == 400
+      assert conn.resp_body == "{\"message\":\"Bad Request\"}"
+      assert conn.halted
+
+      refute_receive {:email, _}
+    end
   end
 end


### PR DESCRIPTION
I made some small changes that allows this library to:

A). Serve as a generic webhook handler (not just Emails)
B.) Accept custom :ok and :error responses

Also, I created a new Adapter (for Hasura Events) but am reluctant to include it in the primary library. My thoughts here are that there are all sorts of possible adapters and you probably don't want to be responsible for maintaining them all. But maybe what I could do is create another library for this adapter and link to it in the README.